### PR TITLE
Feature/manual frag specification

### DIFF
--- a/frags.py
+++ b/frags.py
@@ -4,6 +4,32 @@ import numpy as np
 from numpy import linalg as LA
 from collections import deque
 import logging
+import itertools
+import os
+
+
+def read_geom_from_file(input):
+    f = open(input, "r")
+    natom = int(f.readline().strip().split()[0])
+    xyz_in = np.zeros(natom * 3)
+    xyz_in.shape = (natom, 3)
+    atnum = []
+
+    ### Read in coordinates
+    for i in range(natom):
+        line = f.readline().strip()
+        atnum.append(int(line.split()[0]))
+        for j in range(3):
+            xyz_in[i][j] = line.split()[j + 1]
+    ### Add symbol logic
+    atsym = []
+    for i in atnum:
+        atsym.append(get_symbol(i))
+
+    ### Make a tuple out of atsym and xyz
+    coords = (atsym, xyz_in)
+    return coords
+
 
 def find_mons(input):
     fraglogger=logging.getLogger('frags')
@@ -11,29 +37,12 @@ def find_mons(input):
 ### Slightly modified vdW radii, especially for HF clusters
 ### alkali metal values for cations = 
     cov = {'H' : 1.266, 'Li': 1.8, 'C' : 1.829, 'N' : 1.757, 'O' : 1.682, 
-           'F' : 1.287, 'Na': 1.5, 'P' : 1.9,   'S' : 1.8,   'Cl': 1.7,
-           'Br': 1.8  , 'K' : 1.8, 'Rb': 2.0,   'I' : 1.9,   'Cs': 2.1 }
+           'F' : 1.287, 'Ne': 1.4, 'Na': 1.5,   'P' : 1.9,   'S' : 1.8,   
+           'Cl': 1.7,   'Ar': 1.8, 'Br': 1.8  , 'Kr': 1.8,   'K' : 1.8, 
+           'Rb': 2.0,   'I' : 1.9, 'Cs': 2.1 }
 
-    f = open(input, "r")
-    natom = int(f.readline().strip().split()[0])
-    xyz_in = np.zeros(natom*3)
-    xyz_in.shape=(natom,3)
-    atnum=[]
-
-
-### Read in coordinates
-    for i in range (natom):
-       line = f.readline().strip()
-       atnum.append(int(line.split()[0]))
-       for j in range (3):
-          xyz_in[i][j]= line.split()[j+1]
-### Add symbol logic
-    atsym=[]
-    for i in atnum:
-       atsym.append(get_symbol(i))
-
-### Make a tuple out of atsym and xyz
-    coords = (atsym, xyz_in)
+    atsym, xyz_in = read_geom_from_file(input)
+    natom = len(atsym)
 
 ### Make dist. matrix
     dist = np.zeros(natom*natom)
@@ -79,6 +88,47 @@ def find_mons(input):
                 j=j+1
     
     mons=lol
+
     fraglogger.info('\nIdentified these groups as monomers\n%s\n'%mons)
+    coords = (atsym, xyz_in)
     frag_back = (coords, mons)
     return frag_back
+
+
+def read_mons(input, frag_file):
+    ## Manually specified list of fragments if frags.in provided.
+    f = open(frag_file, "r")
+    lines = f.readlines()
+    f.close()
+    mons = []
+    for line in lines:
+        line = line.strip()
+        # Ignore comments
+        try:
+            if line[0] == "#":
+                continue
+        except IndexError:  # line was empty
+            continue
+
+        # Lines look like  0 1 2 for monomer of atoms 0, 1, and 2 in a frag
+        atoms_in_fragment = line.split()
+        mons.append(atoms_in_fragment)
+
+    coords = read_geom_from_file(input)
+
+    # Lastly, insist that the number of atoms in the manual frag file is correct ( == natom)
+    flat_atoms_list = list(itertools.chain(*mons))  # standard way of flattening a list of lists into 1d array
+    flat_atoms_list.sort()
+    natom = len(coords[0])
+    n_atoms_mapped = len(flat_atoms_list)
+
+    # Fail if n_atoms_mapped != natom
+    assert n_atoms_mapped == natom, "Only mapped " + str(n_atoms_mapped) + \
+                                    " atoms vs natom==" + str(natom) + "!"
+
+    # Checks for missing / repeat atomic indices
+    missing_atoms = [a for a in range(natom) if a not in flat_atoms_list]
+    assert len(missing_atoms) == 0, "Uhoh missing some atoms in the fragment specifications " + \
+                                    str(missing_atoms) + " . I bet you repeated one of the atom indices"
+
+    return coords, mons

--- a/frags.py
+++ b/frags.py
@@ -102,7 +102,7 @@ def read_mons(input, frag_file):
     f.close()
     mons = []
     for line in lines:
-        line = line.strip()
+        line = line.strip()  # throw whitespace away
         # Ignore comments
         try:
             if line[0] == "#":
@@ -112,18 +112,20 @@ def read_mons(input, frag_file):
 
         # Lines look like  0 1 2 for monomer of atoms 0, 1, and 2 in a frag
         atoms_in_fragment = line.split()
+        # Make ints not strings
+        atoms_in_fragment = [int(a) for a in atoms_in_fragment]
         mons.append(atoms_in_fragment)
 
+    # coords is the tuple of (atomic_symbols, xyz_geometry)
     coords = read_geom_from_file(input)
 
-    # Lastly, insist that the number of atoms in the manual frag file is correct ( == natom)
+    # Do a couple of QA checks and raise fatal errors
     flat_atoms_list = list(itertools.chain(*mons))  # standard way of flattening a list of lists into 1d array
-    flat_atoms_list.sort()
     natom = len(coords[0])
     n_atoms_mapped = len(flat_atoms_list)
 
     # Fail if n_atoms_mapped != natom
-    assert n_atoms_mapped == natom, "Only mapped " + str(n_atoms_mapped) + \
+    assert n_atoms_mapped == natom, "Mapped " + str(n_atoms_mapped) + \
                                     " atoms vs natom==" + str(natom) + "!"
 
     # Checks for missing / repeat atomic indices

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import logging,extract,assemble,subprocess
 import newass
 from setup import init,restartJob
 from files import create
-from frags import find_mons
+from frags import find_mons, read_mons
 from COMPS import JOBS
 #from COMPS_pbs import JOBS
 
@@ -58,6 +58,7 @@ f12file=wrkdir+'/f12a'
 rhfile=wrkdir+'/rhf'
 scalefile=wrkdir+'/scale'
 corrFile=wrkdir+'/correlation'
+fragFile=wrkdir+'/frags.in'
 if os.path.exists(tfile):
     print "I found ", tfile
     tflag=True
@@ -83,6 +84,11 @@ if os.path.exists(corrFile):
     CORR=True
 else:
     CORR=False
+if os.path.exists(fragFile):
+    MANUAL_FRAGMENTS = True
+else:
+    MANUAL_FRAGMENTS = False
+
 
 # Configure main.py logger
 mainlogger=logging.getLogger('Iter%s' %suffix)
@@ -93,7 +99,16 @@ mainlogger.info("Deriv = %d\n" %deriv)
 create(wrkdir,scrdir,suffix,level,tflag)
 
 # Call find_mons function to map the monomers
-coords,mons=find_mons(input)
+if MANUAL_FRAGMENTS:
+    mainlogger.info("Requested manual fragment specification...")
+    try:
+        coords,mons=read_mons(input, fragFile)
+    except Exception as e:
+        mainlogger.exception("Had a problem reading manual fragments: ", str(e))
+        raise
+else:
+    mainlogger.info("Performing automatic fragment finding...")
+    coords,mons=find_mons(input)
 
 # Create monomer input
 if level>0:


### PR DESCRIPTION
These changes allow for a text file in the working directory named `frags.in` that specifies a fragment on each line. Comments (start with #) and blank lines are ignored. File specifying 3 separate water monomers may look like:
```
0 1 2
3 4 5
# comments could go anywhere or nowhere
6 7 8
```

Changes: 
- in main.py, check for existence of file `frags.in` in the working dir. If it exists, map the fragments with the new function `read_mons` instead of `find_mons`.
- Code that reads the geometry from file in the `find_mons` function in frags.py was moved into a separate function `read_geom_from_file`, so it could be called in the `read_mons` function. 
- `read_mons` will check that the number of atoms read into fragments is equal to `natom`. It will check that each of the integers in the range 0 to `natom`-1 is in the fragments. It will raise an exception if either of these things is not true.